### PR TITLE
Implement cv （履歴書機能の実装）

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,6 +37,7 @@ group :development, :test do
   gem 'rspec-rails', '~> 4.0.1'
   gem 'factory_bot_rails'
   gem 'faker'
+  gem 'pry-byebug'
 end
 
 group :development do
@@ -46,7 +47,6 @@ group :development do
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
-  gem 'pry-byebug'
   gem 'annotate'
 end
 

--- a/app/assets/stylesheets/cvs.scss
+++ b/app/assets/stylesheets/cvs.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the cvs controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: https://sass-lang.com/

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,21 +1,28 @@
 class ApplicationController < ActionController::Base
-    protect_from_forgery with: :exception
-    before_action :configure_permitted_parameters, if: :devise_controller?
+  protect_from_forgery with: :exception
+  before_action :configure_permitted_parameters, if: :devise_controller?
 
-    protected
-      def configure_permitted_parameters
-        devise_parameter_sanitizer.permit(:sign_up, keys: [:username,:service_id])
-        devise_parameter_sanitizer.permit(:account_update, keys: [:username,:service_id])
-      end
+  protected
+    def configure_permitted_parameters
+      devise_parameter_sanitizer.permit(:sign_up, keys: [:username,:service_id])
+      devise_parameter_sanitizer.permit(:account_update, keys: [:username,:service_id])
+    end
 
-      def after_sign_out_path_for(resource)
-        new_user_session_path
-      end
+    def after_sign_out_path_for(resource)
+      new_user_session_path
+    end
 
-      def check_guest
-        email = resource&.email || params[:user][:email].downcase
-        if email == 'guest@example.com'
-          redirect_to root_path, alert: 'ゲストユーザーの変更・削除はできません。'
-        end
+    def check_guest
+      email = resource&.email || params[:user][:email].downcase
+      if email == 'guest@example.com'
+        redirect_to root_path, alert: 'ゲストユーザーの変更・削除はできません。'
       end
+    end
+
+    def post_action_user_chk
+      if current_user.id != params[:id].to_i
+        flash[:notice] = "不正な入力です。"
+        redirect_to root_path
+      end
+    end    
 end

--- a/app/controllers/cvs_controller.rb
+++ b/app/controllers/cvs_controller.rb
@@ -1,0 +1,64 @@
+class CvsController < ApplicationController
+  before_action :authenticate_user!
+  before_action :set_target_cv, only: %i[new edit update]
+
+  def show
+    @cv =  Cv.eager_load(:user, :objectives, :skills, :summaries, :qualifications, :work_experiences).where(user_id: params[:id])
+  end
+
+  def new
+    if @cv == nil
+      @cv = Cv.new(flash[:cv]) 
+    else
+      redirect_to edit_cv_path
+    end
+  end
+
+  def create
+    cv = Cv.new(cv_params)
+    cv.user_id = params[:id]
+    if cv.save
+      flash[:notice] = "作成しました。"
+      redirect_to cv_path
+    else
+      redirect_to new_cv_path, flash: {
+        cv: cv,
+        alert: cv.errors.full_messages
+      }
+    end
+  end
+
+  def edit
+    if @cv == nil
+      redirect_to new_cv_path
+    end
+    @cv.attributes = flash[:cv] if flash[:cv]
+  end
+
+  def update
+    if @cv.update(cv_params)
+      flash[:notice] = "編集しました。"
+      redirect_to cv_path
+    else
+      redirect_to new_cv_path, flash: {
+        cv: @cv,
+        alert: @cv.errors.full_messages
+      }
+    end
+  end
+
+  private
+
+  def cv_params
+    params.require(:cv).permit(:education, :display, objectives_attributes: [:id, :display, :name, :_destroy], 
+      skills_attributes: [:id, :display, :name, :_destroy],
+      summaries_attributes: [:id, :display, :name, :_destroy],
+      qualifications_attributes: [:id, :display, :name, :_destroy], 
+      work_experiences_attributes: [:id, :display, :description, :_destroy])
+  end
+
+  def set_target_cv
+    user = User.find(params[:id])
+    @cv = user.cv
+  end
+end

--- a/app/controllers/cvs_controller.rb
+++ b/app/controllers/cvs_controller.rb
@@ -4,6 +4,7 @@ class CvsController < ApplicationController
   before_action :post_action_user_chk, only: %i[create update]
 
   def show
+    user = User.find(params[:id])
     @cv =  Cv.eager_load(:user, :objectives, :skills, :summaries, :qualifications, :work_experiences).where(user_id: params[:id])
   end
 

--- a/app/controllers/cvs_controller.rb
+++ b/app/controllers/cvs_controller.rb
@@ -1,16 +1,21 @@
 class CvsController < ApplicationController
   before_action :authenticate_user!
   before_action :set_target_cv, only: %i[new edit update]
+  before_action :post_action_user_chk, only: %i[create update]
 
   def show
     @cv =  Cv.eager_load(:user, :objectives, :skills, :summaries, :qualifications, :work_experiences).where(user_id: params[:id])
   end
 
   def new
-    if @cv == nil
-      @cv = Cv.new(flash[:cv]) 
+    if current_user.id == params[:id].to_i
+      if @cv == nil
+        @cv = Cv.new(flash[:cv]) 
+      else
+        redirect_to edit_cv_path
+      end
     else
-      redirect_to edit_cv_path
+      redirect_to new_cv_path(current_user)
     end
   end
 
@@ -29,10 +34,14 @@ class CvsController < ApplicationController
   end
 
   def edit
-    if @cv == nil
-      redirect_to new_cv_path
+    if current_user.id == params[:id].to_i
+      if @cv == nil
+        redirect_to new_cv_path
+      end
+      @cv.attributes = flash[:cv] if flash[:cv]
+    else
+      redirect_to edit_cv_path(current_user)
     end
-    @cv.attributes = flash[:cv] if flash[:cv]
   end
 
   def update
@@ -61,4 +70,5 @@ class CvsController < ApplicationController
     user = User.find(params[:id])
     @cv = user.cv
   end
+
 end

--- a/app/helpers/cvs_helper.rb
+++ b/app/helpers/cvs_helper.rb
@@ -1,0 +1,2 @@
+module CvsHelper
+end

--- a/app/javascript/cv/del.js
+++ b/app/javascript/cv/del.js
@@ -1,0 +1,5 @@
+export function delForm(delid) {
+  var child = document.getElementById(delid);
+  var parent = child.parentNode;
+  parent.remove();
+}

--- a/app/javascript/cv/form.js
+++ b/app/javascript/cv/form.js
@@ -1,0 +1,7 @@
+import { preaddForm } from './preaddForm';
+
+var objectives_add = preaddForm('objectives','name');
+var summaries_add = preaddForm('summaries','name');
+var skills_add = preaddForm('skills','name');
+var qualifications_add = preaddForm('qualifications','name');
+var work_experiences_add = preaddForm('work_experiences','description');

--- a/app/javascript/cv/preaddForm.js
+++ b/app/javascript/cv/preaddForm.js
@@ -1,0 +1,55 @@
+import { delForm } from './del';
+
+var objectives_itr ;
+var skills_itr ;
+var summaries_itr ;
+var qualifications_itr ;
+var work_experiences_itr ;
+
+export function preaddForm(cv_association, columnname) {
+  var cv_association_add_button = document.getElementById(cv_association + '_button');
+  var parent = cv_association_add_button.parentNode;
+  var parent_tag = parent.getElementsByClassName(cv_association + '_wrap_' + columnname);
+  eval(cv_association + '_itr = ' + parent_tag.length);
+  cv_association_add_button.addEventListener('click', () => addForm(parent, cv_association, columnname, cv_association_add_button));
+}
+
+function addForm(parent, cv_association, columnname, cv_association_add_button) {
+  var cs_association_div = document.createElement('div');
+  var i = eval(cv_association + '_itr');
+  cs_association_div.className = cv_association + '_wrap_' + columnname;
+  parent.appendChild(cs_association_div);
+
+  var input_data = document.createElement('textarea');
+  var del_button = document.createElement('button');
+  input_data.name = 'cv[' + cv_association + '_attributes][' + i + '][' + columnname + ']';
+  input_data.id = 'cv_' + cv_association + '_attributes_' + i + '_' + columnname;
+  del_button.type = 'button';
+  del_button.id = cv_association + '_' + columnname + '_del_' + i;
+
+  var destroy_label = document.createElement('label');
+  destroy_label.append("取消");
+
+  cs_association_div.appendChild(input_data);
+  cs_association_div.appendChild(destroy_label);
+  cs_association_div.appendChild(del_button);
+
+  var display_label = document.createElement('label');
+  var display_checkbox = document.createElement('input');
+  display_label.append("表示する");
+  display_checkbox.type = 'checkbox';
+  display_checkbox.checked = true;
+  display_checkbox.name = 'cv[' + cv_association + '_attributes][' + i + '][display]';
+  display_checkbox.id = 'cv_' + cv_association + '_attributes_' + i + '_display';
+
+  cs_association_div.appendChild(display_label);
+  cs_association_div.appendChild(display_checkbox);
+  
+  //追加ボタンの位置を変更するため
+  parent.appendChild(cv_association_add_button);
+
+  let delbutton = document.getElementById(cv_association + '_' + columnname + '_del_' + i);
+  delbutton.addEventListener('click', () => delForm(delbutton.id));
+
+  eval(cv_association + '_itr++');
+}

--- a/app/javascript/packs/cv/application.js
+++ b/app/javascript/packs/cv/application.js
@@ -3,11 +3,7 @@
 // a relevant structure within app/javascript and only use these pack files to reference
 // that code so it'll be compiled.
 
-require("@rails/ujs").start()
-require("turbolinks").start()
-require("@rails/activestorage").start()
-require("channels")
-
+require("cv/form")
 
 
 // Uncomment to copy all static images under ../images to the output folder and reference

--- a/app/models/cv.rb
+++ b/app/models/cv.rb
@@ -20,19 +20,19 @@
 class Cv < ApplicationRecord
   belongs_to :user
 
-  has_many :objectives
+  has_many :objectives, dependent: :delete_all
   accepts_nested_attributes_for :objectives, allow_destroy: true
 
-  has_many :summaries
+  has_many :summaries, dependent: :delete_all
   accepts_nested_attributes_for :summaries, allow_destroy: true
 
-  has_many :skills
+  has_many :skills, dependent: :delete_all
   accepts_nested_attributes_for :skills, allow_destroy: true
 
-  has_many :qualifications
+  has_many :qualifications, dependent: :delete_all
   accepts_nested_attributes_for :qualifications, allow_destroy: true
 
-  has_many :work_experiences
+  has_many :work_experiences, dependent: :delete_all
   accepts_nested_attributes_for :work_experiences, allow_destroy: true
   
 end

--- a/app/models/cv.rb
+++ b/app/models/cv.rb
@@ -1,0 +1,38 @@
+# == Schema Information
+#
+# Table name: cvs
+#
+#  id         :bigint           not null, primary key
+#  display    :boolean          default(TRUE), not null
+#  education  :string(255)
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  user_id    :bigint           not null
+#
+# Indexes
+#
+#  index_cvs_on_user_id  (user_id) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
+#
+class Cv < ApplicationRecord
+  belongs_to :user
+
+  has_many :objectives
+  accepts_nested_attributes_for :objectives, allow_destroy: true
+
+  has_many :summaries
+  accepts_nested_attributes_for :summaries, allow_destroy: true
+
+  has_many :skills
+  accepts_nested_attributes_for :skills, allow_destroy: true
+
+  has_many :qualifications
+  accepts_nested_attributes_for :qualifications, allow_destroy: true
+
+  has_many :work_experiences
+  accepts_nested_attributes_for :work_experiences, allow_destroy: true
+  
+end

--- a/app/models/objective.rb
+++ b/app/models/objective.rb
@@ -1,0 +1,22 @@
+# == Schema Information
+#
+# Table name: objectives
+#
+#  id         :bigint           not null, primary key
+#  display    :boolean          default(TRUE), not null
+#  name       :string(255)
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  cv_id      :bigint           not null
+#
+# Indexes
+#
+#  index_objectives_on_cv_id  (cv_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (cv_id => cvs.id)
+#
+class Objective < ApplicationRecord
+  belongs_to :cv
+end

--- a/app/models/qualification.rb
+++ b/app/models/qualification.rb
@@ -1,0 +1,22 @@
+# == Schema Information
+#
+# Table name: qualifications
+#
+#  id         :bigint           not null, primary key
+#  display    :boolean          default(TRUE), not null
+#  name       :string(255)
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  cv_id      :bigint           not null
+#
+# Indexes
+#
+#  index_qualifications_on_cv_id  (cv_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (cv_id => cvs.id)
+#
+class Qualification < ApplicationRecord
+  belongs_to :cv
+end

--- a/app/models/skill.rb
+++ b/app/models/skill.rb
@@ -1,0 +1,22 @@
+# == Schema Information
+#
+# Table name: skills
+#
+#  id         :bigint           not null, primary key
+#  display    :boolean          default(TRUE), not null
+#  name       :string(255)
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  cv_id      :bigint           not null
+#
+# Indexes
+#
+#  index_skills_on_cv_id  (cv_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (cv_id => cvs.id)
+#
+class Skill < ApplicationRecord
+  belongs_to :cv
+end

--- a/app/models/summary.rb
+++ b/app/models/summary.rb
@@ -1,0 +1,22 @@
+# == Schema Information
+#
+# Table name: summaries
+#
+#  id         :bigint           not null, primary key
+#  display    :boolean          default(TRUE), not null
+#  name       :string(255)
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  cv_id      :bigint           not null
+#
+# Indexes
+#
+#  index_summaries_on_cv_id  (cv_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (cv_id => cvs.id)
+#
+class Summary < ApplicationRecord
+  belongs_to :cv
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -25,6 +25,7 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
 
+  has_one :cv
   has_many :following_relationships,foreign_key: "follower_id", class_name: "Relationship",  dependent: :destroy
   has_many :followings, through: :following_relationships
   has_many :follower_relationships,foreign_key: "following_id",class_name: "Relationship", dependent: :destroy

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -25,7 +25,7 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
 
-  has_one :cv
+  has_one :cv, dependent: :delete
   has_many :following_relationships,foreign_key: "follower_id", class_name: "Relationship",  dependent: :destroy
   has_many :followings, through: :following_relationships
   has_many :follower_relationships,foreign_key: "following_id",class_name: "Relationship", dependent: :destroy

--- a/app/models/work_experience.rb
+++ b/app/models/work_experience.rb
@@ -1,0 +1,22 @@
+# == Schema Information
+#
+# Table name: work_experiences
+#
+#  id          :bigint           not null, primary key
+#  description :text(65535)
+#  display     :boolean          default(TRUE), not null
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  cv_id       :bigint           not null
+#
+# Indexes
+#
+#  index_work_experiences_on_cv_id  (cv_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (cv_id => cvs.id)
+#
+class WorkExperience < ApplicationRecord
+  belongs_to :cv
+end

--- a/app/views/cvs/_form_field.html.erb
+++ b/app/views/cvs/_form_field.html.erb
@@ -1,0 +1,25 @@
+<div class="form-group">
+    <div id = <%= "" + modelname.to_s + "_group" %> >
+        <span id = <%= "" + modelname.to_s + "" %> ><%= modelname %></span>
+            <% if type == :new %>
+                <%= f.fields_for modelname, cv.send(modelname.to_s).build do |m| %>
+                    <div class = <%= "" + modelname.to_s + "_wrap_" + column.to_s + "" %> >
+                        <%= m.text_area column %>
+                        <%= m.label :display, '表示する' %>
+                        <%= m.check_box :display, class: 'form-control'%>
+                    </div>
+                <% end %>
+            <% else %>
+                <%= f.fields_for modelname, cv.send(modelname.to_s) do |m| %>
+                    <div class = <%= "" + modelname.to_s + "_wrap_" + column.to_s + "" %> >
+                        <%= m.text_area column %>
+                        <%= m.label :_destroy, '削除' %>
+                        <%= m.check_box :_destroy, {}, 1, 0 %>
+                        <%= m.label :display, '表示する' %>
+                        <%= m.check_box :display, class: 'form-control'%>
+                    </div>
+                <% end %>
+            <% end %>
+        <input type="button" value="入力項目追加" id = <%= "" + modelname.to_s + "_button" %> >
+    </div>
+</div>

--- a/app/views/cvs/edit.html.erb
+++ b/app/views/cvs/edit.html.erb
@@ -1,0 +1,21 @@
+<h1>Cvs#edit</h1>
+<p>Find me in app/views/cvs/edit.html.erb</p>
+
+<%= form_with model: @cv, url: cv_path do |f| %>
+    <div class="form-group">
+        <%= f.label :education, '最終学歴' %>
+        <%= f.text_field :education, class: 'form-control'%>
+    </div>
+    <div class="form-group">
+        <%= f.label :display, '公開する' %>
+        <%= f.check_box :display, class: 'form-control'%>
+    </div>
+    <%= render partial: 'form_field' , locals: { cv: @cv, modelname: :objectives, column: :name, f: f, type: :edit } %>
+    <%= render partial: 'form_field' , locals: { cv: @cv, modelname: :summaries, column: :name, f: f, type: :edit } %>
+    <%= render partial: 'form_field' , locals: { cv: @cv, modelname: :skills, column: :name, f: f, type: :edit } %>
+    <%= render partial: 'form_field' , locals: { cv: @cv, modelname: :work_experiences, column: :description, f: f, type: :edit } %>
+    <%= render partial: 'form_field' , locals: { cv: @cv, modelname: :qualifications, column: :name, f: f, type: :edit } %>
+    <%= f.submit '保存', class: 'btn btn-primary' %>
+<% end %>
+
+<%= javascript_pack_tag 'cv/application' %>

--- a/app/views/cvs/new.html.erb
+++ b/app/views/cvs/new.html.erb
@@ -1,0 +1,21 @@
+<h1>Cvs#new</h1>
+<p>Find me in app/views/cvs/new.html.erb</p>
+
+<%= form_with model: @cv, url: cv_path do |f| %>
+    <div class="form-group">
+        <%= f.label :education, '最終学歴' %>
+        <%= f.text_field :education, class: 'form-control'%>
+    </div>
+    <div class="form-group">
+        <%= f.label :display, '公開する' %>
+        <%= f.check_box :display, class: 'form-control'%>
+    </div>
+    <%= render partial: 'form_field' , locals: { cv: @cv, modelname: :objectives, column: :name, f: f, type: :new } %>
+    <%= render partial: 'form_field' , locals: { cv: @cv, modelname: :summaries, column: :name, f: f, type: :new } %>
+    <%= render partial: 'form_field' , locals: { cv: @cv, modelname: :skills, column: :name, f: f, type: :new } %>
+    <%= render partial: 'form_field' , locals: { cv: @cv, modelname: :work_experiences, column: :description, f: f, type: :new } %>
+    <%= render partial: 'form_field' , locals: { cv: @cv, modelname: :qualifications, column: :name, f: f, type: :new } %>
+    <%= f.submit '保存', class: 'btn btn-primary' %>
+<% end %>
+
+<%= javascript_pack_tag 'cv/application' %>

--- a/app/views/cvs/show.html.erb
+++ b/app/views/cvs/show.html.erb
@@ -1,0 +1,65 @@
+<h1>Cvs#show</h1>
+<p>Find me in app/views/cvs/show.html.erb</p>
+
+<% @cv.each do |cv| %>
+    <% if cv.display == true %>
+        <table class="outline fadeInUp">
+            <tr>
+                <th>名前</th>
+                <td align="left"><%= cv.user.username %></td>
+            </tr>
+            <tr>
+                <th>EMAIL</th>
+                <td align="left"><%= cv.user.email %></td>
+            </tr>
+            <tr>
+                <th>希望職種</th>
+                <td align="left">
+                    <% cv.objectives.each do |objective| %>
+                        <% if objective.display == true %>
+                            <div><%= objective.name %></div>
+                        <% end %>
+                    <% end %>
+                </td>
+            </tr>
+            <tr>
+                <th>サマリ</th>
+                <td align="left">
+                    <% cv.summaries.each do |summary| %>
+                        <div><%= summary.name %></div>
+                    <% end %>
+                </td>
+            </tr>
+            <tr>
+                <th>スキル</th>
+                <td align="left">
+                    <% cv.skills.each do |skill| %>
+                        <div><%= skill.name %></div>
+                    <% end %>
+                </td>
+            </tr>
+            <tr>
+                <th>職歴</th>
+                <td align="left">
+                    <% cv.work_experiences.each do |work_experience| %>
+                        <div><%= work_experience.description %></div>
+                    <% end %>
+                </td>
+            </tr>
+            <tr>
+                <th>資格</th>
+                <td align="left">
+                    <% cv.qualifications.each do |qualification| %>
+                        <div><%= qualification.name %></div>
+                    <% end %>
+                </td>
+            </tr>
+            <tr>
+                <th>最終学歴</th>
+                <td align="left"><%= cv.education %></td>
+            </tr>
+        </table>
+    <% else %>
+        <p>非公開に設定されているため閲覧することは出来ません</p>
+    <% end %>
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -17,6 +17,9 @@
     <li><%= link_to 'ホーム', root_path %></li>
     <% if user_signed_in? %>
       <li><a href="/users/<%= current_user.id %>">マイページ</a></li>
+      <li><a href="/users/<%= current_user.id %>/cv/new">履歴書作成</a></li>
+      <li><a href="/users/<%= current_user.id %>/cv/edit">履歴書編集</a></li>
+      <li><a href="/users/<%= current_user.id %>/cv">履歴書</a></li>
       <li><%= link_to 'ユーザー一覧', users_path %></li>
       <li><%= link_to 'ログアウト', destroy_user_session_path, method: :delete %></li>
     <% else %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,8 +12,10 @@ Rails.application.routes.draw do
   resources :users, only: [:index, :show] do 
     member do
       get :followings, :followers
+      resource :cv, only: [:show, :new, :create, :edit, :update]
     end
   end 
+  
   resources :relationships, only: [:create, :destroy]
 
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html

--- a/db/migrate/20210107055930_create_cvs.rb
+++ b/db/migrate/20210107055930_create_cvs.rb
@@ -1,0 +1,11 @@
+class CreateCvs < ActiveRecord::Migration[6.0]
+  def change
+    create_table :cvs do |t|
+      t.belongs_to :user, null: false, index: { unique: true }, foreign_key: true
+      t.string :education
+      t.boolean :display, default: true, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20210107144526_create_objectives.rb
+++ b/db/migrate/20210107144526_create_objectives.rb
@@ -1,0 +1,11 @@
+class CreateObjectives < ActiveRecord::Migration[6.0]
+  def change
+    create_table :objectives do |t|
+      t.references :cv, null: false, foreign_key: true
+      t.string :name
+      t.boolean :display, default: true, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20210109025327_create_qualifications.rb
+++ b/db/migrate/20210109025327_create_qualifications.rb
@@ -1,0 +1,11 @@
+class CreateQualifications < ActiveRecord::Migration[6.0]
+  def change
+    create_table :qualifications do |t|
+      t.references :cv, null: false, foreign_key: true
+      t.string :name
+      t.boolean :display, default: true, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20210109043515_create_work_experiences.rb
+++ b/db/migrate/20210109043515_create_work_experiences.rb
@@ -1,0 +1,11 @@
+class CreateWorkExperiences < ActiveRecord::Migration[6.0]
+  def change
+    create_table :work_experiences do |t|
+      t.references :cv, null: false, foreign_key: true
+      t.text :description
+      t.boolean :display, default: true, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20210109080739_create_skills.rb
+++ b/db/migrate/20210109080739_create_skills.rb
@@ -1,0 +1,11 @@
+class CreateSkills < ActiveRecord::Migration[6.0]
+  def change
+    create_table :skills do |t|
+      t.references :cv, null: false, foreign_key: true
+      t.string :name
+      t.boolean :display, default: true, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20210109090238_create_summaries.rb
+++ b/db/migrate/20210109090238_create_summaries.rb
@@ -1,0 +1,11 @@
+class CreateSummaries < ActiveRecord::Migration[6.0]
+  def change
+    create_table :summaries do |t|
+      t.references :cv, null: false, foreign_key: true
+      t.string :name
+      t.boolean :display, default: true, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,34 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_18_025835) do
+ActiveRecord::Schema.define(version: 2021_01_09_090238) do
+
+  create_table "cvs", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.string "education"
+    t.boolean "display", default: true, null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["user_id"], name: "index_cvs_on_user_id", unique: true
+  end
+
+  create_table "objectives", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "cv_id", null: false
+    t.string "name"
+    t.boolean "display", default: true, null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["cv_id"], name: "index_objectives_on_cv_id"
+  end
+
+  create_table "qualifications", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "cv_id", null: false
+    t.string "name"
+    t.boolean "display", default: true, null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["cv_id"], name: "index_qualifications_on_cv_id"
+  end
 
   create_table "relationships", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "follower_id"
@@ -20,6 +47,24 @@ ActiveRecord::Schema.define(version: 2020_12_18_025835) do
     t.index ["follower_id", "following_id"], name: "index_relationships_on_follower_id_and_following_id", unique: true
     t.index ["follower_id"], name: "index_relationships_on_follower_id"
     t.index ["following_id"], name: "index_relationships_on_following_id"
+  end
+
+  create_table "skills", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "cv_id", null: false
+    t.string "name"
+    t.boolean "display", default: true, null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["cv_id"], name: "index_skills_on_cv_id"
+  end
+
+  create_table "summaries", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "cv_id", null: false
+    t.string "name"
+    t.boolean "display", default: true, null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["cv_id"], name: "index_summaries_on_cv_id"
   end
 
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
@@ -37,6 +82,21 @@ ActiveRecord::Schema.define(version: 2020_12_18_025835) do
     t.index ["service_id"], name: "index_users_on_service_id", unique: true
   end
 
+  create_table "work_experiences", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "cv_id", null: false
+    t.text "description"
+    t.boolean "display", default: true, null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["cv_id"], name: "index_work_experiences_on_cv_id"
+  end
+
+  add_foreign_key "cvs", "users"
+  add_foreign_key "objectives", "cvs"
+  add_foreign_key "qualifications", "cvs"
   add_foreign_key "relationships", "users", column: "follower_id"
   add_foreign_key "relationships", "users", column: "following_id"
+  add_foreign_key "skills", "cvs"
+  add_foreign_key "summaries", "cvs"
+  add_foreign_key "work_experiences", "cvs"
 end

--- a/spec/factories/cvs.rb
+++ b/spec/factories/cvs.rb
@@ -1,0 +1,24 @@
+# == Schema Information
+#
+# Table name: cvs
+#
+#  id         :bigint           not null, primary key
+#  display    :boolean          default(TRUE), not null
+#  education  :string(255)
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  user_id    :bigint           not null
+#
+# Indexes
+#
+#  index_cvs_on_user_id  (user_id) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
+#
+FactoryBot.define do
+  factory :cv do
+    user { nil }
+  end
+end

--- a/spec/factories/cvs.rb
+++ b/spec/factories/cvs.rb
@@ -19,6 +19,17 @@
 #
 FactoryBot.define do
   factory :cv do
-    user { nil }
+    association :user 
+    education {"大学"}
+
+    trait :with_nested_instances do
+      after( :create ) do |cv|
+        create :objective, cv_id: cv.id
+        create :qualification, cv_id: cv.id
+        create :skill, cv_id: cv.id
+        create :summary, cv_id: cv.id
+        create :work_experience, cv_id: cv.id
+      end
+    end
   end
 end

--- a/spec/factories/objectives.rb
+++ b/spec/factories/objectives.rb
@@ -19,7 +19,7 @@
 #
 FactoryBot.define do
   factory :objective do
-    cv { nil }
-    jobname { "MyText" }
+    association :cv
+    name { "objective職業" }
   end
 end

--- a/spec/factories/objectives.rb
+++ b/spec/factories/objectives.rb
@@ -1,0 +1,25 @@
+# == Schema Information
+#
+# Table name: objectives
+#
+#  id         :bigint           not null, primary key
+#  display    :boolean          default(TRUE), not null
+#  name       :string(255)
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  cv_id      :bigint           not null
+#
+# Indexes
+#
+#  index_objectives_on_cv_id  (cv_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (cv_id => cvs.id)
+#
+FactoryBot.define do
+  factory :objective do
+    cv { nil }
+    jobname { "MyText" }
+  end
+end

--- a/spec/factories/qualifications.rb
+++ b/spec/factories/qualifications.rb
@@ -1,0 +1,25 @@
+# == Schema Information
+#
+# Table name: qualifications
+#
+#  id         :bigint           not null, primary key
+#  display    :boolean          default(TRUE), not null
+#  name       :string(255)
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  cv_id      :bigint           not null
+#
+# Indexes
+#
+#  index_qualifications_on_cv_id  (cv_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (cv_id => cvs.id)
+#
+FactoryBot.define do
+  factory :qualification do
+    cv { nil }
+    qualyficationname { "MyString" }
+  end
+end

--- a/spec/factories/qualifications.rb
+++ b/spec/factories/qualifications.rb
@@ -19,7 +19,7 @@
 #
 FactoryBot.define do
   factory :qualification do
-    cv { nil }
-    qualyficationname { "MyString" }
+    association :cv
+    name { "qualification資格" }
   end
 end

--- a/spec/factories/skills.rb
+++ b/spec/factories/skills.rb
@@ -19,7 +19,7 @@
 #
 FactoryBot.define do
   factory :skill do
-    cv { nil }
-    name { "MyString" }
+    association :cv
+    name { "skillスキル" }
   end
 end

--- a/spec/factories/skills.rb
+++ b/spec/factories/skills.rb
@@ -1,0 +1,25 @@
+# == Schema Information
+#
+# Table name: skills
+#
+#  id         :bigint           not null, primary key
+#  display    :boolean          default(TRUE), not null
+#  name       :string(255)
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  cv_id      :bigint           not null
+#
+# Indexes
+#
+#  index_skills_on_cv_id  (cv_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (cv_id => cvs.id)
+#
+FactoryBot.define do
+  factory :skill do
+    cv { nil }
+    name { "MyString" }
+  end
+end

--- a/spec/factories/summaries.rb
+++ b/spec/factories/summaries.rb
@@ -1,0 +1,25 @@
+# == Schema Information
+#
+# Table name: summaries
+#
+#  id         :bigint           not null, primary key
+#  display    :boolean          default(TRUE), not null
+#  name       :string(255)
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  cv_id      :bigint           not null
+#
+# Indexes
+#
+#  index_summaries_on_cv_id  (cv_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (cv_id => cvs.id)
+#
+FactoryBot.define do
+  factory :summary do
+    cv { nil }
+    name { "MyString" }
+  end
+end

--- a/spec/factories/summaries.rb
+++ b/spec/factories/summaries.rb
@@ -19,7 +19,7 @@
 #
 FactoryBot.define do
   factory :summary do
-    cv { nil }
-    name { "MyString" }
+    association :cv
+    name { "summaryサマリ" }
   end
 end

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -1,18 +1,18 @@
 FactoryBot.define do
-    pass = Faker::Internet.password(min_length: 6, mix_case: true, special_characters: false)
-    factory :user, aliases: [:following, :follower] do
-        service_id            { Faker::Internet.username(specifier: 6)}
-        username              { Faker::Name.name }
-        email                 { Faker::Internet.email }
-        password              { pass }
-        password_confirmation { pass }
-    end
+  pass = Faker::Internet.password(min_length: 6, mix_case: true, special_characters: false)
+  factory :user, aliases: [:following, :follower] do
+      service_id            { Faker::Internet.username(specifier: 6)}
+      username              { Faker::Name.name }
+      email                 { Faker::Internet.email }
+      password              { pass }
+      password_confirmation { pass }
+  end
 
-    factory :testuser, class: User do
-        service_id            { Faker::Internet.username(specifier: 6)}
-        username              { Faker::Name.name }
-        email                 { Faker::Internet.email }
-        password              { pass }
-        password_confirmation { pass }
-    end
+  factory :testuser, class: User do
+      service_id            { Faker::Internet.username(specifier: 6)}
+      username              { Faker::Name.name }
+      email                 { Faker::Internet.email }
+      password              { pass }
+      password_confirmation { pass }
+  end
 end

--- a/spec/factories/work_experiences.rb
+++ b/spec/factories/work_experiences.rb
@@ -1,0 +1,25 @@
+# == Schema Information
+#
+# Table name: work_experiences
+#
+#  id          :bigint           not null, primary key
+#  description :text(65535)
+#  display     :boolean          default(TRUE), not null
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  cv_id       :bigint           not null
+#
+# Indexes
+#
+#  index_work_experiences_on_cv_id  (cv_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (cv_id => cvs.id)
+#
+FactoryBot.define do
+  factory :work_experience do
+    cv { nil }
+    description { "MyText" }
+  end
+end

--- a/spec/factories/work_experiences.rb
+++ b/spec/factories/work_experiences.rb
@@ -19,7 +19,7 @@
 #
 FactoryBot.define do
   factory :work_experience do
-    cv { nil }
-    description { "MyText" }
+    association :cv
+    description { "work_experience職歴" }
   end
 end

--- a/spec/helpers/cvs_helper_spec.rb
+++ b/spec/helpers/cvs_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the CvsHelper. For example:
+#
+# describe CvsHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe CvsHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/cv_spec.rb
+++ b/spec/models/cv_spec.rb
@@ -20,5 +20,69 @@
 require 'rails_helper'
 
 RSpec.describe Cv, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe 'Association' do
+    let(:association) do
+       described_class.reflect_on_association(target)
+    end
+
+    context 'Userとのアソシエーション' do
+      let(:target) { :user }
+      it 'belong_to（１対多）になっていること' do
+         expect(association.macro).to eq :belongs_to 
+      end
+      it 'Cvと関連していること' do
+         expect(association.class_name).to eq 'User' 
+      end
+    end
+
+    context 'Objectivesとのアソシエーション' do
+      let(:target) { :objectives }
+      it 'has_many（1対多）になっていること' do
+         expect(association.macro).to eq :has_many
+      end
+      it 'Objectiveと関連していること' do
+         expect(association.class_name).to eq 'Objective' 
+      end
+    end
+
+    context 'qualificationsとのアソシエーション' do
+      let(:target) { :qualifications }
+      it 'has_many（1対多）になっていること' do
+         expect(association.macro).to eq :has_many
+      end
+      it 'Qualificationと関連していること' do
+        expect(association.class_name).to eq 'Qualification' 
+      end
+    end
+
+    context 'skillsとのアソシエーション' do
+      let(:target) { :skills }
+      it 'has_many（1対多）になっていること' do
+         expect(association.macro).to eq :has_many
+      end
+      it 'Skillと関連していること' do
+         expect(association.class_name).to eq 'Skill' 
+      end
+    end
+
+    context 'summariesとのアソシエーション' do
+      let(:target) { :summaries }
+      it 'has_many（1対多）になっていること' do
+         expect(association.macro).to eq :has_many
+      end
+      it 'Summaryと関連していること' do
+         expect(association.class_name).to eq 'Summary' 
+      end
+    end
+
+    context 'work_experiencesとのアソシエーション' do
+      let(:target) { :work_experiences }
+      it 'has_many（1対多）になっていること' do
+         expect(association.macro).to eq :has_many
+      end
+      it 'WorkExperienceと関連していること' do
+         expect(association.class_name).to eq 'WorkExperience' 
+      end
+    end
+  end
 end

--- a/spec/models/cv_spec.rb
+++ b/spec/models/cv_spec.rb
@@ -1,0 +1,24 @@
+# == Schema Information
+#
+# Table name: cvs
+#
+#  id         :bigint           not null, primary key
+#  display    :boolean          default(TRUE), not null
+#  education  :string(255)
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  user_id    :bigint           not null
+#
+# Indexes
+#
+#  index_cvs_on_user_id  (user_id) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
+#
+require 'rails_helper'
+
+RSpec.describe Cv, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/objective_spec.rb
+++ b/spec/models/objective_spec.rb
@@ -1,0 +1,24 @@
+# == Schema Information
+#
+# Table name: objectives
+#
+#  id         :bigint           not null, primary key
+#  display    :boolean          default(TRUE), not null
+#  name       :string(255)
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  cv_id      :bigint           not null
+#
+# Indexes
+#
+#  index_objectives_on_cv_id  (cv_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (cv_id => cvs.id)
+#
+require 'rails_helper'
+
+RSpec.describe Objective, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/objective_spec.rb
+++ b/spec/models/objective_spec.rb
@@ -20,5 +20,19 @@
 require 'rails_helper'
 
 RSpec.describe Objective, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe 'Association' do
+    let(:association) do
+       described_class.reflect_on_association(target)
+    end
+
+    context 'Cvとのアソシエーション' do
+      let(:target) { :cv }
+      it 'belong_to（１対多）になっていること' do
+         expect(association.macro).to eq :belongs_to 
+      end
+      it 'cvと関連していること' do
+         expect(association.class_name).to eq 'Cv' 
+      end
+    end
+  end
 end

--- a/spec/models/qualification_spec.rb
+++ b/spec/models/qualification_spec.rb
@@ -1,0 +1,24 @@
+# == Schema Information
+#
+# Table name: qualifications
+#
+#  id         :bigint           not null, primary key
+#  display    :boolean          default(TRUE), not null
+#  name       :string(255)
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  cv_id      :bigint           not null
+#
+# Indexes
+#
+#  index_qualifications_on_cv_id  (cv_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (cv_id => cvs.id)
+#
+require 'rails_helper'
+
+RSpec.describe Qualification, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/qualification_spec.rb
+++ b/spec/models/qualification_spec.rb
@@ -20,5 +20,19 @@
 require 'rails_helper'
 
 RSpec.describe Qualification, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe 'Association' do
+    let(:association) do
+       described_class.reflect_on_association(target)
+    end
+
+    context 'Cvとのアソシエーション' do
+      let(:target) { :cv }
+      it 'belong_to（１対多）になっていること' do
+         expect(association.macro).to eq :belongs_to 
+      end
+      it 'cvと関連していること' do
+         expect(association.class_name).to eq 'Cv' 
+      end
+    end
+  end
 end

--- a/spec/models/skill_spec.rb
+++ b/spec/models/skill_spec.rb
@@ -20,5 +20,19 @@
 require 'rails_helper'
 
 RSpec.describe Skill, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe 'Association' do
+    let(:association) do
+       described_class.reflect_on_association(target)
+    end
+
+    context 'Cvとのアソシエーション' do
+      let(:target) { :cv }
+      it 'belong_to（１対多）になっていること' do
+         expect(association.macro).to eq :belongs_to 
+      end
+      it 'cvと関連していること' do
+         expect(association.class_name).to eq 'Cv' 
+      end
+    end
+  end
 end

--- a/spec/models/skill_spec.rb
+++ b/spec/models/skill_spec.rb
@@ -1,0 +1,24 @@
+# == Schema Information
+#
+# Table name: skills
+#
+#  id         :bigint           not null, primary key
+#  display    :boolean          default(TRUE), not null
+#  name       :string(255)
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  cv_id      :bigint           not null
+#
+# Indexes
+#
+#  index_skills_on_cv_id  (cv_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (cv_id => cvs.id)
+#
+require 'rails_helper'
+
+RSpec.describe Skill, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/summary_spec.rb
+++ b/spec/models/summary_spec.rb
@@ -20,5 +20,19 @@
 require 'rails_helper'
 
 RSpec.describe Summary, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe 'Association' do
+    let(:association) do
+       described_class.reflect_on_association(target)
+    end
+
+    context 'Cvとのアソシエーション' do
+      let(:target) { :cv }
+      it 'belong_to（１対多）になっていること' do
+         expect(association.macro).to eq :belongs_to 
+      end
+      it 'cvと関連していること' do
+         expect(association.class_name).to eq 'Cv' 
+      end
+    end
+  end
 end

--- a/spec/models/summary_spec.rb
+++ b/spec/models/summary_spec.rb
@@ -1,0 +1,24 @@
+# == Schema Information
+#
+# Table name: summaries
+#
+#  id         :bigint           not null, primary key
+#  display    :boolean          default(TRUE), not null
+#  name       :string(255)
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  cv_id      :bigint           not null
+#
+# Indexes
+#
+#  index_summaries_on_cv_id  (cv_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (cv_id => cvs.id)
+#
+require 'rails_helper'
+
+RSpec.describe Summary, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -170,5 +170,15 @@ RSpec.describe User, type: :model do
          expect(association.class_name).to eq 'Relationship' 
       end
     end
+
+    context 'Cvとのアソシエーション' do
+      let(:target) { :cv }
+      it 'has_one（1対1）になっていること' do
+         expect(association.macro).to eq :has_one
+      end
+      it 'Cvと関連していること' do
+         expect(association.class_name).to eq 'Cv' 
+      end
+    end
   end
 end

--- a/spec/models/work_experience_spec.rb
+++ b/spec/models/work_experience_spec.rb
@@ -20,5 +20,19 @@
 require 'rails_helper'
 
 RSpec.describe WorkExperience, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe 'Association' do
+    let(:association) do
+       described_class.reflect_on_association(target)
+    end
+
+    context 'Cvとのアソシエーション' do
+      let(:target) { :cv }
+      it 'belong_to（１対多）になっていること' do
+         expect(association.macro).to eq :belongs_to 
+      end
+      it 'cvと関連していること' do
+         expect(association.class_name).to eq 'Cv' 
+      end
+    end
+  end
 end

--- a/spec/models/work_experience_spec.rb
+++ b/spec/models/work_experience_spec.rb
@@ -1,0 +1,24 @@
+# == Schema Information
+#
+# Table name: work_experiences
+#
+#  id          :bigint           not null, primary key
+#  description :text(65535)
+#  display     :boolean          default(TRUE), not null
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  cv_id       :bigint           not null
+#
+# Indexes
+#
+#  index_work_experiences_on_cv_id  (cv_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (cv_id => cvs.id)
+#
+require 'rails_helper'
+
+RSpec.describe WorkExperience, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/requests/cvs_request_spec.rb
+++ b/spec/requests/cvs_request_spec.rb
@@ -1,33 +1,201 @@
 require 'rails_helper'
 
 RSpec.describe "Cvs", type: :request do
+  let(:user) { create(:user) }
+  let(:cv) { create(:cv, :with_nested_instances) }
+  let(:othercv) { create(:cv, :with_nested_instances) }
 
-  describe "GET /new" do
-    it "returns http success" do
-      get "/cvs/new"
-      expect(response).to have_http_status(:success)
+  before do
+    @params_nested = { 
+      cv: FactoryBot.attributes_for(:cv, user: user.id).
+        merge( 
+          objectives_attributes: {
+            "0": attributes_for(:objective)
+          },
+          qualifications_attributes: {
+            "0": attributes_for(:qualification)
+          },
+          skills_attributes: {
+            "0": attributes_for(:skill)
+          },
+          summaries_attributes: {
+            "0": attributes_for(:summary)
+          },
+          work_experiences_attributes: {
+            "0": attributes_for(:work_experience)
+          }
+        )
+    }
+  end
+
+  describe 'GET cvs #show' do
+    context 'ログインしている場合' do
+      before do
+        sign_in cv.user
+      end
+      context 'ユーザーが存在する時' do
+        it 'マイページを表示すること' do
+          expect( get cv_path(id: cv.user.id) ).to eq 200
+        end
+        it '他ユーザーページを表示すること' do
+          expect( get cv_path(id: othercv.user.id) ).to eq 200
+        end
+      end
+      context 'ユーザーが存在しない場合' do
+        it 'エラーが発生すること' do
+          nobody = cv.user.id + 1
+          expect{ get cv_path(id: nobody) }.to raise_error ActiveRecord::RecordNotFound
+        end
+      end
+    end
+    context 'ログインしていない場合' do
+      it 'ログインページにリダイレクトすること' do
+        get cv_path(id: cv.user.id)
+        expect(response).to redirect_to new_user_session_path
+      end
     end
   end
 
-  describe "GET /create" do
-    it "returns http success" do
-      get "/cvs/create"
-      expect(response).to have_http_status(:success)
+  describe 'GET cvs #new' do
+    context 'ログインしている場合' do
+      context 'cvをまだ作成していないユーザーの場合' do
+        before do
+          sign_in user
+        end
+        it 'リクエストが成功すること' do
+          get new_cv_path(user.id)
+          expect(response.status).to eq 200
+        end
+        it '対象が異なる場合、リダイレクトされること' do
+          get new_cv_path(othercv.user.id)
+          expect(response.status).to eq 302
+        end
+        it '対象が異なる場合、ログインユーザーのnewページへリダイレクトされること' do
+          get new_cv_path(othercv.user.id)
+          expect(response).to redirect_to new_cv_path(user.id)
+        end
+      end
+      context 'cvが作成済みのユーザーの場合' do
+        before do
+          sign_in cv.user
+        end
+        it 'リダイレクトすること' do
+          get new_cv_path(cv.user.id)
+          expect(response.status).to eq 302
+        end
+        it 'editページへリダイレクトすること' do
+          get new_cv_path(cv.user.id)
+          expect(response).to redirect_to edit_cv_path(cv.user.id)
+        end
+      end
+    end
+    context 'ログインしていない場合' do
+      it 'リダイレクトされること' do
+        get new_cv_path(cv.user.id)
+        expect(response).to redirect_to new_user_session_path
+      end
     end
   end
 
-  describe "GET /edit" do
-    it "returns http success" do
-      get "/cvs/edit"
-      expect(response).to have_http_status(:success)
+  describe 'POST cvs #create' do
+    context 'ログインしている場合' do
+      before do
+        sign_in user
+      end
+      it 'リクエストが成功すること' do
+        post cv_path(id: user.id), params: @params_nested
+        expect(response.status).to eq 302
+      end
+      it 'createが成功すること' do
+        expect do
+          post cv_path(id: user.id), params: @params_nested
+        end.to change(Cv, :count).by 1
+      end
+    end
+    context 'ログインしていない場合' do
+      it 'リダイレクトされること' do
+        post cv_path(id: user.id), params: @params_nested
+        expect(response.status).to eq 302
+      end
+      it 'ログインページにリダイレクトすること' do
+        post cv_path(id: user.id), params: @params_nested
+        expect(response).to redirect_to new_user_session_path
+      end
     end
   end
 
-  describe "GET /update" do
-    it "returns http success" do
-      get "/cvs/update"
-      expect(response).to have_http_status(:success)
+  describe 'GET cvs #edit' do
+    context 'ログインしている場合' do
+      context 'cvをまだ作成していないユーザーの場合' do
+        before do
+          sign_in user
+        end
+        it 'リダイレクトすること' do
+          get edit_cv_path(user.id)
+          expect(response.status).to eq 302
+        end
+        it 'newページへリダイレクトすること' do
+          get edit_cv_path(user.id)
+          expect(response).to redirect_to new_cv_path(user.id)
+        end
+      end 
+      context 'cvが作成済みのユーザーの場合' do
+        before do
+          sign_in cv.user
+        end
+        it 'リクエストが成功すること' do
+          get edit_cv_path(cv.user.id)
+          expect(response.status).to eq 200
+        end
+        it '対象が異なる場合、リダイレクトされること' do
+          get edit_cv_path(othercv.user.id)
+          expect(response.status).to eq 302
+        end
+        it '対象が異なる場合、ログインユーザーのeditページへリダイレクトされること' do
+          get edit_cv_path(othercv.user.id)
+          expect(response).to redirect_to edit_cv_path(cv.user.id)
+        end
+      end
+    end
+    context 'ログインしていない場合' do
+      it 'リダイレクトされること' do
+        get edit_cv_path(cv.user.id)
+        expect(response).to redirect_to new_user_session_path
+      end
     end
   end
 
+  describe 'PUT cvs #update' do
+    context 'ログインしている場合' do
+      before do
+        sign_in cv.user
+      end
+      it 'リクエストが成功すること' do
+        put cv_path(id: cv.user.id), params: { cv: { id: cv.id, education: "高校" } }
+        expect(response.status).to eq 302
+      end
+      it 'updateが成功すること' do
+        put cv_path(id: cv.user.id), params: { cv: { id: cv.id, education: "高校" } }
+        expect(cv.reload.education).to eq "高校"
+      end
+      it "ユーザー編集ページへリダイレクトすること" do
+        put cv_path(id: cv.user.id), params: { cv: { id: cv.id, education: "高校" } }
+        expect(response).to redirect_to cv_path(id: cv.user.id)
+      end
+      it "対象がログインユーザー以外の場合、rootへリダイレクトすること" do
+        put cv_path(id: othercv.user.id), params: { cv: { id: cv.id, education: "高校" } }
+        expect(response).to redirect_to root_path
+      end
+    end
+    context 'ログインしていない場合' do
+      it 'リダイレクトされること' do
+        put cv_path(id: cv.user.id), params: { cv: { id: cv.id, education: "高校" } }
+        expect(response.status).to eq 302
+      end
+      it 'ログインページへリダイレクトされること' do
+        put cv_path(id: cv.user.id), params: { cv: { id: cv.id, education: "高校" } }
+        expect(response).to redirect_to new_user_session_path
+      end
+    end
+  end
 end

--- a/spec/requests/cvs_request_spec.rb
+++ b/spec/requests/cvs_request_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe "Cvs", type: :request do
+
+  describe "GET /new" do
+    it "returns http success" do
+      get "/cvs/new"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe "GET /create" do
+    it "returns http success" do
+      get "/cvs/create"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe "GET /edit" do
+    it "returns http success" do
+      get "/cvs/edit"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe "GET /update" do
+    it "returns http success" do
+      get "/cvs/update"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+end

--- a/spec/requests/relationships_request_spec.rb
+++ b/spec/requests/relationships_request_spec.rb
@@ -1,102 +1,102 @@
 require 'rails_helper'
 
 RSpec.describe "Relationships", type: :request do
-	let!(:user) { create(:user) }
-	let!(:testuser) { create(:testuser) }
+  let!(:user) { create(:user) }
+  let!(:testuser) { create(:testuser) }
 
-	describe 'POST relationship #create' do
-		context 'ログインしている場合' do
-			before do
-				sign_in user
-			end
-			it 'リクエストが成功すること' do
-				post relationships_path, params: { relationship: { following_id: testuser.id } }, xhr: true
-				expect(response.status).to eq 200
-			end
-			it 'createが成功すること' do
-				expect do
-					post relationships_path, params: { relationship: { following_id: testuser.id } }, xhr: true
-				end.to change(Relationship, :count).by 1
-			end
-		end
-		context 'ログインしていない場合' do
-			it 'リクエストが失敗すること' do
-				post relationships_path, params: { relationship: { following_id: testuser.id } }, xhr: true
-				expect(response.status).to eq 401
-			end
-		end
+  describe 'POST relationship #create' do
+    context 'ログインしている場合' do
+      before do
+        sign_in user
+      end
+      it 'リクエストが成功すること' do
+        post relationships_path, params: { relationship: { following_id: testuser.id } }, xhr: true
+        expect(response.status).to eq 200
+      end
+      it 'createが成功すること' do
+        expect do
+          post relationships_path, params: { relationship: { following_id: testuser.id } }, xhr: true
+        end.to change(Relationship, :count).by 1
+      end
+    end
+    context 'ログインしていない場合' do
+      it 'リクエストが失敗すること' do
+        post relationships_path, params: { relationship: { following_id: testuser.id } }, xhr: true
+        expect(response.status).to eq 401
+      end
+    end
   end
 
   describe 'DELETE relationship #destroy' do
     let(:followed){ create( :relationship, follower_id: user.id, following_id: testuser.id ) }
     context 'ログインしている場合' do
-			before do
+      before do
         sign_in user
-			end
-			it 'リクエストが成功すること' do
+      end
+      it 'リクエストが成功すること' do
         delete relationship_path(followed), params: { relationship: { following_id: testuser.id } }, xhr: true
-				expect(response.status).to eq 200
-			end
+        expect(response.status).to eq 200
+      end
       it 'deleteが成功すること' do
         #expectで、letの遅延評価によりfollowedが作成されてしまうため、countが変わらないように
         #expectの前に変数を宣言している。
         followed 
-				expect do
+        expect do
           delete relationship_path(followed), params: { relationship: { following_id: testuser.id } }, xhr: true
-				end.to change(Relationship, :count).by -1
-			end
-		end
-		context 'ログインしていない場合' do
-			it 'リクエストが失敗すること' do
+        end.to change(Relationship, :count).by -1
+      end
+    end
+    context 'ログインしていない場合' do
+      it 'リクエストが失敗すること' do
         delete relationship_path(followed), params: { relationship: { following_id: testuser.id } }, xhr: true
-				expect(response.status).to eq 401
-			end
-		end
+        expect(response.status).to eq 401
+      end
+    end
   end
 
   describe 'get user #followings' do
-		context 'ログインしている場合' do
-			before do
-				sign_in user
-			end
-			it 'ユーザーが存在しリクエストが成功すること' do
-				get followings_user_path(user)
-				expect(response.status).to eq 200
-			end
+    context 'ログインしている場合' do
+      before do
+        sign_in user
+      end
+      it 'ユーザーが存在しリクエストが成功すること' do
+        get followings_user_path(user)
+        expect(response.status).to eq 200
+      end
       it 'ユーザーが存在せずリクエストが失敗すること' do
         testuser_id = testuser.id
         testuser.destroy
         expect{ get followings_user_path(testuser_id) }.to raise_error ActiveRecord::RecordNotFound
-			end
-		end
+      end
+    end
     context 'ログインしていない場合' do
       it 'ログインページにリダイレクトすること' do
         get followings_user_path(user)
         expect(response).to redirect_to new_user_session_path
       end
-		end
+    end
   end
 
   describe 'get user #followers' do
-		context 'ログインしている場合' do
-			before do
-				sign_in user
-			end
-			it 'ユーザーが存在しリクエストが成功すること' do
-				get followers_user_path(user)
-				expect(response.status).to eq 200
-			end
+    context 'ログインしている場合' do
+      before do
+        sign_in user
+      end
+      it 'ユーザーが存在しリクエストが成功すること' do
+        get followers_user_path(user)
+        expect(response.status).to eq 200
+      end
       it 'ユーザーが存在せずリクエストが失敗すること' do
         testuser_id = testuser.id
         testuser.destroy
         expect{ get followers_user_path(testuser_id) }.to raise_error ActiveRecord::RecordNotFound
-			end
-		end
+      end
+    end
     context 'ログインしていない場合' do
       it 'ログインページにリダイレクトすること' do
         get followers_user_path(user)
         expect(response).to redirect_to new_user_session_path
       end
-		end
+    end
   end
 end

--- a/spec/views/cvs/edit.html.erb_spec.rb
+++ b/spec/views/cvs/edit.html.erb_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "cvs/edit.html.erb", type: :view do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/views/cvs/new.html.erb_spec.rb
+++ b/spec/views/cvs/new.html.erb_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "cvs/new.html.erb", type: :view do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/views/cvs/show.html.erb_spec.rb
+++ b/spec/views/cvs/show.html.erb_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "cvs/show.html.erb", type: :view do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
履歴書機能を実装。

1. cvsテーブルの作成
2. cvsに関連する子テーブルを作成
　-objectives
    -summaries
    -skills
    -qualifications
    -work_experiences
3. cvs及び関連テーブルのテストを作成（request,model）