### PR TITLE
タイトル表示がされなかったため修正、一部CSSの変更

### DIFF
--- a/app/views/cvs/_form_field.html.erb
+++ b/app/views/cvs/_form_field.html.erb
@@ -1,12 +1,26 @@
+<% inputsize_mini = false %>
+<% case modelname %>
+  <% when :objectives then %>
+    <% model_disp_word = "現在の職種（又は希望職種）" %>
+  <% when :summaries then %>
+    <% model_disp_word = "要約（職歴やスキルなど）" %>
+  <% when :skills then %>
+    <% model_disp_word = "スキル" %>
+  <% when :work_experiences then %>
+    <% model_disp_word = "職歴" %>
+  <% when :qualifications then %>
+    <% model_disp_word = "資格" %>
+<% end %>
+
 <div class="my-2">
   <div id = <%= "" + modelname.to_s + "_group" %> >
-    <span id = <%= "" + modelname.to_s + "" %> ><%= modelname %></span>
+    <span id = <%= "" + modelname.to_s + "" %> ><%= model_disp_word %></span>
       <% if type == :new %>
         <%= f.fields_for modelname, cv.send(modelname.to_s).build do |m| %>
           <div class = "<%= modelname.to_s + "_wrap_" + column.to_s %>
             flex">
             <%= m.text_area column, 
-              class: "w-5/12 bg-gray-100 rounded border border-gray-400 leading-normal resize-none 
+              class: "w-5/12 bg-gray-100 rounded border border-gray-400 leading-normal
                     w-full h-24 py-2 px-3 mb-3 font-medium placeholder-gray-700 focus:outline-none 
                     focus:bg-white" %>
             <div class="flex flex-col w-2/12 place-content-center mx-2 mb-3" >
@@ -22,7 +36,7 @@
           <div class = "<%= modelname.to_s + "_wrap_" + column.to_s%> 
             flex">
             <%= m.text_area column,
-              class: "w-5/12 bg-gray-100 rounded border border-gray-400 leading-normal resize-none 
+              class: "w-5/12 bg-gray-100 rounded border border-gray-400 leading-normal
                     w-full h-24 py-2 px-3 mb-3 font-medium placeholder-gray-700 focus:outline-none 
                     focus:bg-white" %>
             <div class="flex flex-col w-2/12 place-content-center mx-2" >

--- a/app/views/cvs/edit.html.erb
+++ b/app/views/cvs/edit.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:title) { 'CVの編集' } %>
 <div class="max-w-2xl md:w-3/4 py-4 mx-auto">
   <div class="my-4 font-medium"></div>
 

--- a/app/views/cvs/new.html.erb
+++ b/app/views/cvs/new.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:title) { 'CVの新規作成' } %>
 <div class="max-w-2xl md:w-3/4 py-4 mx-auto">
   <div class="my-4 font-medium"></div>
 

--- a/app/views/cvs/show.html.erb
+++ b/app/views/cvs/show.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:title) { 'CVページ' } %>
 <div class="max-w-2xl w-full md:w-3/4 py-4 mx-auto">
   <div class="">
     <div class="my-4 font-medium">
@@ -20,8 +21,8 @@
               <td class="py-4 px-6"><%= cv.user.email %></td>
             </tr>
             <tr class="border-b border-grey-light">
-              <td class="py-4 px-6 ">希望職種</td>
-              <td class="flex flex-col py-4 px-6 whitespace-pre-line">
+              <td class="py-4 px-6 ">現在の職種（希望職種）</td>
+              <td class="flex flex-col py-4 px-6 whitespace-pre-wrap">
                 <% cv.objectives.each do |objective| %>
                   <% if objective.display == true %>
                     <span><%= objective.name %></span>
@@ -30,8 +31,8 @@
               </td>
             </tr>
             <tr class="border-b border-grey-light">
-              <td class="py-4 px-6">サマリ</td>
-              <td class="flex flex-col py-4 px-6 whitespace-pre-line">
+              <td class="py-4 px-6">要約（職歴やスキルなど）</td>
+              <td class="flex flex-col py-4 px-6 whitespace-pre-wrap">
                 <% cv.summaries.each do |summary| %>
                   <% if summary.display == true %>
                     <span><%= summary.name %></span>
@@ -41,7 +42,7 @@
             </tr>
             <tr class="border-b border-grey-light">
               <td class="py-4 px-6">スキル</td>
-              <td class="flex flex-col py-4 px-6 whitespace-pre-line">
+              <td class="flex flex-col py-4 px-6 whitespace-pre-wrap">
                 <% cv.skills.each do |skill| %>
                   <% if skill.display == true %>
                     <span><%= skill.name %></span>
@@ -51,7 +52,7 @@
             </tr>
             <tr class="border-b border-grey-light">
               <td class="py-4 px-6">職歴</td>
-              <td class="flex flex-col py-4 px-6 whitespace-pre-line">
+              <td class="flex flex-col py-4 px-6 whitespace-pre-wrap">
                 <% cv.work_experiences.each do |work_experience| %>
                 <% if work_experience.display == true %>
                     <span><%= work_experience.description %></span>
@@ -61,7 +62,7 @@
             </tr>
             <tr class="border-b border-grey-light">
               <td class="py-4 px-6">資格</td>
-              <td class="flex flex-col py-4 px-6 whitespace-pre-line">
+              <td class="flex flex-col py-4 px-6 whitespace-pre-wrap">
                 <% cv.qualifications.each do |qualification| %>
                   <% if qualification.display == true %>
                     <span><%= qualification.name %></span>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:title) { 'ユーザー情報の変更' } %>
 <%= render "devise/shared/error_messages", resource: resource %>
 <div class="container max-w-2xl md:w-3/4 py-4 mx-auto">
   <div class="px-4 my-4 font-medium">ユーザー編集画面</div>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:title) { 'Sign Up' } %>
 <%= render "devise/shared/error_messages", resource: resource %>
 <div class="container max-w-2xl md:w-3/4 py-4 mx-auto">
   <div class="px-4 my-4 font-medium">新規登録画面</div>

--- a/app/views/homes/index.html.erb
+++ b/app/views/homes/index.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:title) { 'ホーム' } %>
 <div class="mx-auto px-4 py-4 sm:ml-0 sm:pl-0 sm:mr-auto sm:pr-4">
   <% if user_signed_in? %>
     <div class="flex items-baseline">

--- a/app/views/homes/search.html.erb
+++ b/app/views/homes/search.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:title) { '検索結果' } %>
 <div class="max-w-2xl md:w-3/4 py-4 mx-2">
   <div class="mb-4">
     <h1 class="text-xl">検索結果</h1>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,8 +1,7 @@
 <!DOCTYPE html>
 <html lang="ja">
   <head>
-    <!--<title>Myapp</title>-->
-    <title><%= yield(:title) || 'Portfolio' %></title>
+    <title>CNS<%= content_for?(:title) ? " | " + yield(:title) : "" %></title>
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
     <meta name="viewport" content="width=device-width,initial-scale=1.0,minimum-scale=1.0">

--- a/app/views/microposts/_micropost.html.erb
+++ b/app/views/microposts/_micropost.html.erb
@@ -15,7 +15,7 @@
         <span class="timestamp ml-auto mr-2 text-right">
         ・<%= time_ago_in_words(micropost.created_at) %></span>
       </div>
-      <div class="content pt-3 pb-8"><%= micropost.content %></div>
+      <div class="content pt-3 pb-8 whitespace-pre-wrap"><%= micropost.content %></div>
     </div>
   </div>
   <div class="micropost_buttons_wrap flex" id="micropost_buttons_wrap">

--- a/app/views/microposts/show.html.erb
+++ b/app/views/microposts/show.html.erb
@@ -1,3 +1,5 @@
+<% content_for(:title) { '詳細な投稿' } %>
+
 <div class="max-w-2xl md:w-3/4 py-4">
   <div class="px-4 my-4 font-medium">Micropost</div>
   <div class="before_main_microposts">

--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:title) { '詳細な投稿' } %>
 <% notifications = @notifications.eager_load(:visitor, :visited, :reply_micropost, main_micropost: :user).where.not(visitor_id: current_user.id) %>
 <div class="max-w-2xl md:w-3/4 py-4 mx-2">
   <div class="px-4 my-4 font-medium">通知</div>

--- a/app/views/rooms/index.html.erb
+++ b/app/views/rooms/index.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:title) { 'DMのユーザー一覧' } %>
 <div class="max-w-2xl md:w-3/4 py-4 mx-2">
   <div class="px-4 my-4 font-medium">DM</div>
   <% if @rooms_present == true %>

--- a/app/views/rooms/show.html.erb
+++ b/app/views/rooms/show.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:title) { 'DM' } %>
 <div class="max-w-2xl md:w-3/4 py-4 mx-2">
   <div class="px-4 my-4 font-medium">DM</div>
   <h1 class="text-center"></h1>


### PR DESCRIPTION
タイトル表記がされなかったため修正いたしました。

1. 全ページにタイトル表記処理を追加

CSSの変更点

1. micropostの参照にて文章の改行・空白を保持するよう変更
2. CV作成・編集ページの入力幅が変更できるよう変更